### PR TITLE
Update to Kibana v4.0.0-stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl
 
-ENV KIBANA_VERSION 4.0.0-rc1-linux-x64
+ENV KIBANA_VERSION 4.0.0-linux-x64
 RUN curl -s https://download.elasticsearch.org/kibana/kibana/kibana-$KIBANA_VERSION.tar.gz | tar xz -C /tmp
 RUN mv /tmp/kibana-* /app
 


### PR DESCRIPTION
Update container to use the stable release of Kibana v4.

If users are upgrading from Kibana v4-RC1 they may need to run the following command to upgrade (more information available ([here](https://github.com/elasticsearch/kibana/issues/3098)):

```
BODY=`curl -XGET 'localhost:9200/.kibana/config/4.0.0-rc1/_source'`; curl -XPUT "localhost:9200/.kibana/config/4.0.0" -d "$BODY" && curl -XDELETE "localhost:9200/.kibana/config/4.0.0-rc1"
```
