### PR TITLE
Update current build to Kibana 4.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl
 
-ENV KIBANA_VERSION 4.0.0-linux-x64
+ENV KIBANA_VERSION 4.0.1-linux-x64
 RUN curl -s https://download.elasticsearch.org/kibana/kibana/kibana-$KIBANA_VERSION.tar.gz | tar xz -C /tmp
 RUN mv /tmp/kibana-* /app
 


### PR DESCRIPTION
Hi,

Is it possible for you to upgrade to Kibana 4.0.1? It's too bad to keep thousand of Kibana images on Docker hub since yours is great :)

Thanks!
