### PR TITLE
Updated Dockerfile Kibana Download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -q && \
     curl
 
 ENV KIBANA_VERSION 4.0.2-linux-x64
-RUN curl -s https://download.elasticsearch.org/kibana/kibana/kibana-$KIBANA_VERSION.tar.gz | tar xz -C /tmp
+RUN curl -s https://download.elastic.co/kibana/kibana/kibana-$KIBANA_VERSION.tar.gz | tar xz -C /tmp
 RUN mv /tmp/kibana-* /app
 
 WORKDIR /app


### PR DESCRIPTION
Noticed when building that the the old elasticsearch.org URL was unreachable and worked when I used the new domain elastic.co. The orginal URL is no longer broken and seems to work again. Maybe the Dockerfile should pull from the new URL just in case?
