### PR TITLE
Updating Kibana version to address security vulnerability CVE-2015-4093

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl
 
-ENV KIBANA_VERSION 4.0.2-linux-x64
+ENV KIBANA_VERSION 4.1.0-linux-x64
 RUN curl -s https://download.elasticsearch.org/kibana/kibana/kibana-$KIBANA_VERSION.tar.gz | tar xz -C /tmp
 RUN mv /tmp/kibana-* /app
 


### PR DESCRIPTION
Updated Dockerfile to use new docker version. Test build and ran container with Kibana 4.1.0 x64 and web interface was accessible on Docker launch. This update is to address security vulnerability: http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-4093
