### PR TITLE
Updating to Kibana 4.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl
 
-ENV KIBANA_VERSION 4.1.2-linux-x64
+ENV KIBANA_VERSION 4.1.4-linux-x64
 RUN curl -s https://download.elastic.co/kibana/kibana/kibana-$KIBANA_VERSION.tar.gz | tar xz -C /tmp
 RUN mv /tmp/kibana-* /app
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Available Kibana Versions:
 `4.0.1`  
 `4.0.2`  
 `4.1.0`  
-`4.1.1`, `latest`
+`4.1.1`
+`4.1.4`, `latest`
 
 ## Run
 To connect to an elasticsearch server on the docker host, run this:


### PR DESCRIPTION
Updating Kibana to version 4.1.4, the latest compatible with elasticsearch 1.7.x. Have built and tested on Docker 1.9.
